### PR TITLE
Exit loop earlier when no YouTube or Vimeo iframe

### DIFF
--- a/js/dsgvo-video-embed.js
+++ b/js/dsgvo-video-embed.js
@@ -16,15 +16,18 @@
      var video_frame, wall, video_platform, video_src, video_id, video_w, video_h;
      for (var i=0, max = window.frames.length - 1; i <= max; i+=1) {
        video_frame = document.getElementsByTagName('iframe')[0];
-       video_w = video_frame.getAttribute('width');
-       video_h = video_frame.getAttribute('height');
        video_src = video_frame.src;
-       video_iframes.push(video_frame);
-       wall = document.createElement('article');
-       // Only proccess video iframes [youtube|vimeo]
+       // Only process video iframes [youtube|vimeo]
        if (video_src.match(/youtube|vimeo/) == null) {
          continue;
        }
+      
+       video_iframes.push(video_frame);
+       video_w = video_frame.getAttribute('width');
+       video_h = video_frame.getAttribute('height');
+       wall = document.createElement('article');
+      
+      
        // Prevent iframes from loading remote content
        if (typeof (window.frames[0].stop) === 'undefined'){
        	setTimeout(function() {window.frames[0].execCommand('Stop');},1000);


### PR DESCRIPTION
There is no reason to do the operations at line 25-28 when the current iframe is not one that ought to be blocked. In contrast, it may even introduce a bug on pages with multiple iframes, when the `video_iframes` array is accessed in line 49 and may lead to the wrong `iframe.src` being replaced.

Also fixed a typo in the comment in line 20.

Also, in general, i'd refrain from tying `data-index` to the loop variable `i`, as this looks like it's going to fall over on pages with multiple iframes containing vimeo/youtube aw well as other content. I'd suggest to tie `data-index` to `video_iframes.length - 1`, that would make it much more stable from looking at it. Haven't tested this though, and that should be dealt with in a separate issue.